### PR TITLE
Array API changes for supporting cupy arrays

### DIFF
--- a/skimage/transform/_warps.py
+++ b/skimage/transform/_warps.py
@@ -735,11 +735,16 @@ def _clip_warp_output(input_image, output_image, mode, cval, clip):
 
         if preserve_cval:
             cval_mask = output_image == cval
-
-        np.clip(output_image, min_val, max_val, out=output_image)
+        if hasattr(output_image, '_array'):
+            np.clip(output_image._array, min_val, max_val, out=output_image._array)
+        else:
+            np.clip(output_image, min_val, max_val, out=output_image)
 
         if preserve_cval:
-            output_image[cval_mask] = cval
+            if hasattr(output_image, '_array'):
+                output_imagie._array[cval_mask] = cval
+            else:
+                output_image[cval_mask] = cval
 
 
 def warp(image, inverse_map, map_args={}, output_shape=None, order=None,

--- a/skimage/transform/_warps.py
+++ b/skimage/transform/_warps.py
@@ -142,7 +142,6 @@ def resize(image, output_shape, order=None, mode='reflect', cval=0, clip=True,
     (100, 100)
 
     """
-
     image, output_shape = _preprocess_resize_output_shape(image, output_shape)
     input_shape = image.shape
     input_type = image.dtype
@@ -188,6 +187,7 @@ def resize(image, output_shape, order=None, mode='reflect', cval=0, clip=True,
         # The grid_mode kwarg was introduced in SciPy 1.6.0
         zoom_factors = [1 / f for f in factors]
         import cupy.array_api as cpx
+        xp, array_api = get_namespace(image)
         if isinstance(image, cpx._array_object.Array):
             from cupyx.scipy import ndimage as cpx_ndi
             zoom_func = cpx_ndi.zoom
@@ -195,6 +195,7 @@ def resize(image, output_shape, order=None, mode='reflect', cval=0, clip=True,
             zoom_func = ndi.zoom
         out = zoom_func(image, zoom_factors, order=order, mode=ndi_mode,
                        cval=cval, grid_mode=True)
+        out = xp.asarray(out)
 
     # TODO: Remove the fallback code below once SciPy >= 1.6.0 is required.
 

--- a/skimage/util/array_compatibility.py
+++ b/skimage/util/array_compatibility.py
@@ -1,0 +1,24 @@
+import numpy as np
+
+
+def get_namespace(*xs):
+    # `xs` contains one or more arrays, or possibly Python scalars (accepting
+    # those is a matter of taste, but doesn't seem unreasonable).
+    namespaces = {
+        x.__array_namespace__() if hasattr(x, '__array_namespace__') else None
+        for x in xs if not isinstance(x, (bool, int, float, complex))
+    }
+
+    if not namespaces:
+        # one could special-case np.ndarray above or use np.asarray here if
+        # older numpy versions need to be supported.
+        raise ValueError("Unrecognized array input")
+
+    if len(namespaces) != 1:
+        raise ValueError(f"Multiple namespaces for array inputs: {namespaces}")
+
+    xp, = namespaces
+    if xp is None:
+        # Use numpy as default
+        return np, False
+    return xp, True


### PR DESCRIPTION
## Description

<!-- If this is a bug-fix or enhancement, state the issue # it closes -->
<!-- If this is a new feature, reference what paper it implements. -->


## Checklist

<!-- It's fine to submit PRs which are a work in progress! -->
<!-- But before they are merged, all PRs should provide: -->
- [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- Gallery example in `./doc/examples` (new features only)
- Benchmark in `./benchmarks`, if your changes aren't covered by an
  existing benchmark
- Unit tests
- Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)
- Descriptive commit messages (see below)

<!-- For detailed information on these and other aspects see -->
<!-- the scikit-image contribution guidelines. -->
<!-- https://scikit-image.org/docs/dev/contribute.html -->

## For reviewers

<!-- Don't remove the checklist below. -->
- Check that the PR title is short, concise, and will make sense 1 year
  later.
- Check that new functions are imported in corresponding `__init__.py`.
- Check that new features, API changes, and deprecations are mentioned in
  `doc/release/release_dev.rst`.
- There is a bot to help automate backporting a PR to an older branch. For
  example, to backport to v0.19.x after merging, add the following in a PR
  comment: `@meeseeksdev backport to v0.19.x`
- To run benchmarks on a PR, add the `run-benchmark` label. To rerun, the label
  can be removed and then added again. The benchmark output can be checked in
  the "Actions" tab.
